### PR TITLE
Bug fixed: search suggestion appears twice.

### DIFF
--- a/src/components/UI/AutoSuggestSearch.tsx
+++ b/src/components/UI/AutoSuggestSearch.tsx
@@ -34,11 +34,10 @@ const AutoSuggestSearch: FC<AutoSuggestSearchProps> = ({ label, allSuggestions, 
     const starts = [];
     const match = [];
     let i = 0;
-    while ((starts.length < 10 || match.length < 10) && i < allSuggestions.length) {
+    while (starts.length < 10 && i < allSuggestions.length) {
       if (allSuggestions[i].name.startsWith(cleanValue)) {
         starts.push(allSuggestions[i]);
-      }
-      if (allSuggestions[i].name.match(cleanValue)) {
+      } else if (match.length < 10 && allSuggestions[i].name.match(cleanValue)) {
         match.push(allSuggestions[i]);
       }
       i++;


### PR DESCRIPTION
If there were less than 10 items in the search suggestion the matching term would appear twice
fixed that